### PR TITLE
"special-characters" test generated incorrect a result

### DIFF
--- a/plugins/bh-client-matchers.js
+++ b/plugins/bh-client-matchers.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let gutil = require('gulp-util');
 let through2 = require('through2');
 
 function getWrappedTemplate(fileContents) {

--- a/test/bh-client-matchers/index.js
+++ b/test/bh-client-matchers/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let fs = require('fs');
 let path = require('path');
 let gutil = require('gulp-util');
 let expect = require('chai').expect;
@@ -7,7 +8,7 @@ let expect = require('chai').expect;
 let bhClientMatchers = require('../../')['bh-client-matchers'];
 let File = gutil.File;
 let collectStreamFiles = require('../../lib/collect-stream-files');
-const specialCharactersTemplate = require('./special-characters');
+const specialCharactersTemplate = fs.readFileSync(path.join(__dirname, 'special-characters.js'), {encoding: 'utf8'});
 
 function clientTemplate(bh) {
     bh.match('block', function (ctx, json) {
@@ -37,7 +38,6 @@ function fillInputFiles(files, stream) {
 
 describe('bh-client-matchers', () => {
     it('should produce expected output', () => {
-        let stream = gutil.noop();
         let myPluginStream = bhClientMatchers();
         let blocks = ['user', 'award', 'page'];
 
@@ -65,7 +65,7 @@ describe('bh-client-matchers', () => {
         let myPluginStream = bhClientMatchers();
         const vinylFile = new File({
             path: resolveFilePath('block'),
-            contents: new Buffer(specialCharactersTemplate + '')
+            contents: new Buffer(specialCharactersTemplate)
         });
 
         myPluginStream.write(vinylFile);


### PR DESCRIPTION
export of a template was deleted

result code:

``` javascript
modules.require('bh', function (bh) {
    var obj = {};

    (function (module) {
        // start
        function (bh) {  // missing `module.exports = ...`
            var ESCAPE_REGEX_SYMBOLS = ['.', '\\', '+', '*', '?', '[', '^', ']', '$', '(', ')', '{', '}', '=', '!', '<', '>', '|', ':', '-'];

            bh.match({
                'input__suggest-item': function (ctx, json) {
                    return ESCAPE_REGEX_SYMBOLS;
                }
            });
        }
        // and now end
    })(obj);

    obj.exports && obj.exports(bh);
});
```
